### PR TITLE
add $workspace/bin to PATH so that the correct autoconf tools are called

### DIFF
--- a/Bash/Installer Scripts/GNU Software/build-gcc
+++ b/Bash/Installer Scripts/GNU Software/build-gcc
@@ -118,6 +118,7 @@ unset tmp_dbus tmp_display tmp_home tmp_pwd tmp_term var
 #
 
 PATH="\
+"${workspace}/bin":\
 /usr/lib/ccache:\
 ${HOME}/perl5/bin:\
 ${HOME}/.cargo/bin:\


### PR DESCRIPTION
Hello,

On ubuntu 22.04, GCC (all versions) won’t build with this script as-is, due to GCC requesting that autoreconf from autoconf-2.69 be used.

I see that this script automatically pulls down and builds autoconf-2.69 and puts it into ${workspace}, but it neither adds ${workspace}/bin to PATH nor does it explicitly call the correct autoreconf (it will run the autoreconf that exists on the system packaged by Ubuntu, which is too new).

I am suggesting to add it to the script’s PATH. The alternative would be to explicitly call autoreconf with the full path.

I was able to start the builds for GCC 11, 12, 13 but not GCC 10 with the older, locally-built autoconf. (Note, I did not see the builds other than GCC 13 through to completion as I’m only interested in GCC 13 and not the older versions, but I can at least state they start compiling after getting past autoreconf and configure).

GCC 10 got past the autoreconf command and failed looking for some GNAT dependencies. Since GCC 10 didn’t like autoconf 2.71 I think it is just a dependency issue and not an autoconf issue.