### PR TITLE
Fix Google Search URL Encoding Issue

### DIFF
--- a/AHK-v2/OpenChromeHere.ahk
+++ b/AHK-v2/OpenChromeHere.ahk
@@ -72,5 +72,15 @@ GetDefaultBrowser() {
 }
 
 UrlEncode(str) {
-    return RegExReplace(str, "[!#$&'()*+,/:;=?@[\]%\s]", "%$0")
+    encoded := ""
+    allowed := "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~"
+    Loop Parse, str {
+        if InStr(allowed, A_LoopField) {
+            encoded .= A_LoopField
+        } else {
+            hex := Format("{:02X}", Ord(A_LoopField))
+            encoded .= "%" . hex
+        }
+    }
+    return encoded
 }


### PR DESCRIPTION


The UrlEncode function now correctly encodes each character by checking against allowed characters and converting others to their percent-encoded values (e.g., spaces become %20).

This ensures that phrases like "how to bake a pie" are encoded as how%20to%20bake%20a%20pie, resulting in a single, properly formatted Google search URL.